### PR TITLE
Add "GetCredit" method with example

### DIFF
--- a/ArubaCloud/PyArubaAPI.py
+++ b/ArubaCloud/PyArubaAPI.py
@@ -482,3 +482,18 @@ class CloudInterface(JsonInterface):
         json_scheme = self.gen_def_json_scheme('SetEnqueueServerRestore', method_fields=restore_request)
         json_obj = self.call_method_post(method='SetEnqueueServerRestore', json_scheme=json_scheme)
         return True if json_obj['Success'] is True else False
+
+    def get_credit(self):
+        """
+        Retrieve the available credit balance.
+        :return: The credit balance as a float.
+        """
+        json_scheme = self.gen_def_json_scheme('GetCredit')
+        json_obj = self.call_method_post(method='GetCredit', json_scheme=json_scheme)
+
+        if json_obj.get('Success'):
+            credit_balance = json_obj['Value']['Value']
+            return credit_balance
+        else:
+            print("Failed to retrieve credit balance.")
+            return None

--- a/examples/get_credit.py
+++ b/examples/get_credit.py
@@ -1,0 +1,17 @@
+import argparse
+
+from ArubaCloud.PyArubaAPI import CloudInterface
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-d', '--datacenter', help='Specify datacenter to login.', action='store', type=int, dest='dc')
+    parser.add_argument('-u', '--username', help='Specify username.', action='store', dest='username')
+    parser.add_argument('-w', '--password', help='Specify password.', action='store', dest='password')
+    p = parser.parse_args()
+
+    i = CloudInterface(dc=p.dc)
+    i.login(username=p.username, password=p.password, load=True)
+
+    credit = i.get_credit()
+    if credit is not None:
+        print(f"Credit: {credit} EUR")


### PR DESCRIPTION
Added a new function to PyArubaAPI.py that calls the "[GetCredit](https://docs.computing.cloud.it/api/WsEndUser/2.9/html/M_Aruba_Cloud_WsEndUser_IWsEndUser_GetCredit.htm)" method to retrieve the available credit.

Also added a new example demonstrating this function, which prints the available credit in EUR.